### PR TITLE
Update banking calendar version to 0.6.1

### DIFF
--- a/lib/banking_calendar/version.rb
+++ b/lib/banking_calendar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BankingCalendar
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
This pull request includes a version update for the `BankingCalendar` module.

* [`lib/banking_calendar/version.rb`](diffhunk://#diff-efd8acc85b9dca02260dd6553248b1b3969c7e87c2500d7891b188fceab4d178L4-R4): Updated the version from `0.6.0` to `0.6.1`.